### PR TITLE
Added gtype conversions for cgo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,9 +62,10 @@ gbmod/
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# We need the go.work to build locally, without fetching from github.
 # Go workspace file
-go.work
-go.work.sum
+# go.work
+# go.work.sum
 
 # env file
 .env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_subdirectory(src)
 set_target_properties(
 	${TARGET_GOBIND}
 	PROPERTIES
-	CXX_STANDARD 20
+	CXX_STANDARD 17
 )
 
 # Define include directories for headers

--- a/go.work
+++ b/go.work
@@ -1,0 +1,7 @@
+go 1.24.2
+
+use (
+	./src/cmd/gobind
+	./src/lib/cgobind
+	./src/lib/go_util
+)

--- a/src/cmd/gobind/bind/bind.go
+++ b/src/cmd/gobind/bind/bind.go
@@ -18,8 +18,8 @@ import (
 	"os"
 	"unsafe"
 
-	util "github.com/soerlemans/gobind/src/lib/go_util"
 	_ "github.com/soerlemans/gobind/src/lib/cgobind"
+	util "github.com/soerlemans/gobind/src/lib/go_util"
 )
 
 // Globals:
@@ -123,6 +123,21 @@ func InitModule(t_handle unsafe.Pointer, t_name string) (*C.GobindModule, error)
 	return module, err
 }
 
+func PrettyPrintModule(t_handle unsafe.Pointer, t_module *C.GobindModule) error {
+	sym, err := DlSym(t_handle, "gobind_module_pprint")
+	if err != nil {
+		return err
+	}
+
+	// Need to cast, to satisfy type system.
+	modulePtr := unsafe.Pointer(t_module)
+
+	// Pretty print the gobind module.
+	C.call_gobind_module_pprint(sym, modulePtr)
+
+	return nil
+}
+
 /*
 func freeModule(t_handle, unsafe.Pointer) error {
 sym, err := DlSym(t_handle, "gobind_module_free")
@@ -167,6 +182,9 @@ func walkModules(t_handle unsafe.Pointer, t_registeredModules []string, t_librar
 		if err != nil {
 			return err
 		}
+
+		// Print the module for good measure.
+		PrettyPrintModule(t_handle, module)
 
 		// FIXME: Free the module.
 		// defer freeModule(module)

--- a/src/cmd/gobind/bind/module.go.tmpl
+++ b/src/cmd/gobind/bind/module.go.tmpl
@@ -70,7 +70,7 @@ func init() {
 
 {{/* Meat of the template, generates wrappers for C/C++ functions. */}}
 {{range .Functions}}
-func {{.Name}}({{.Params}}) {{.ReturnType}} {
+func {{.Name}}() {{.ReturnType}} {
 	  // Call function inside of exportedFunctions map.
 	  fnStruct := exportedFunctions["{{.Name}}"]
 	  fnPtr := unsafe.Pointer(fnStruct.m_fn)

--- a/src/cmd/gobind/bind/module.go.tmpl
+++ b/src/cmd/gobind/bind/module.go.tmpl
@@ -68,6 +68,7 @@ func init() {
 		}
 }
 
+{{/* Meat of the template, generates wrappers for C/C++ functions. */}}
 {{range .Functions}}
 func {{.Name}}({{.Params}}) {{.ReturnType}} {
 	  // Call function inside of exportedFunctions map.

--- a/src/cmd/gobind/bind/template.go
+++ b/src/cmd/gobind/bind/template.go
@@ -30,10 +30,10 @@ import (
 var MODULE_TEMPLATE string
 
 // Structs:
-// Contains all data necessary to create 
+// Contains the pairs for C types and Golang types
 type ParameterData struct {
-	Name string
-	Type string
+	GoType string
+	CType string
 }
 
 // Contains all data necessary to create a wrapper for a function.

--- a/src/cmd/gobind/bind/template.go
+++ b/src/cmd/gobind/bind/template.go
@@ -33,7 +33,7 @@ var MODULE_TEMPLATE string
 // Contains the pairs for C types and Golang types
 type ParameterData struct {
 	GoType string
-	CType string
+	CType  string
 }
 
 // Contains all data necessary to create a wrapper for a function.
@@ -45,9 +45,9 @@ type FunctionData struct {
 
 // Contains toplevel data for the Golang template module.
 type TemplateData struct {
-	Package     string `Golang package name to use.`
-	LibraryDir  string `Directory to add to the linker path using -L.`
-	LibraryName string `Library name to link against using -l.`
+	Package     string         `Golang package name to use.`
+	LibraryDir  string         `Directory to add to the linker path using -L.`
+	LibraryName string         `Library name to link against using -l.`
 	Functions   []FunctionData `Looped through to create the wrapper functions.`
 }
 

--- a/src/cmd/gobind/bind/template.go
+++ b/src/cmd/gobind/bind/template.go
@@ -30,25 +30,34 @@ import (
 var MODULE_TEMPLATE string
 
 // Structs:
-type FunctionData struct {
-	Name       string
-	Params     string
-	ReturnType string
+// Contains all data necessary to create 
+type ParameterData struct {
+	Name string
+	Type string
 }
 
+// Contains all data necessary to create a wrapper for a function.
+type FunctionData struct {
+	Name       string `Name of the function.`
+	Params     string `Parameters`
+	ReturnType string `Golang return type of the function.`
+}
+
+// Contains toplevel data for the Golang template module.
 type TemplateData struct {
-	Package     string
-	LibraryDir  string
-	LibraryName string
-	Functions   []FunctionData
+	Package     string `Golang package name to use.`
+	LibraryDir  string `Directory to add to the linker path using -L.`
+	LibraryName string `Library name to link against using -l.`
+	Functions   []FunctionData `Looped through to create the wrapper functions.`
 }
 
 // Struct TemplateContext:
+// Contains all the context needed for executing the wrapper module template.
 type TemplateContext struct {
-	Module      *C.GobindModule    ``
-	LibraryPath string             ``
-	File        *os.File           ``
-	Tmpl        *template.Template ``
+	Module      *C.GobindModule    `GobindModule struct to unpack and create bindings for.`
+	LibraryPath string             `Absolute path to the library.`
+	File        *os.File           `File to execute template to.`
+	Tmpl        *template.Template `Store the template in memory.`
 }
 
 // Methods TemplateContext:

--- a/src/lib/cgobind/cgobind_helper.c
+++ b/src/lib/cgobind/cgobind_helper.c
@@ -3,7 +3,8 @@
 // Typedefs:
 typedef void* (*void_fn_ptr)(void);
 typedef GobindRegistery* (*registered_modules_fn_ptr)(void);
-typedef GobindModule* (*gobind_fn_ptr)(void);
+typedef GobindModule* (*gobind_module_init_fn_ptr)(void);
+typedef void (*gobind_module_pprint_fn_ptr)(GobindModule*);
 typedef const char* (*gtype2str_fn_ptr)(GType);
 
 // Functions:
@@ -19,7 +20,12 @@ GobindRegistery* call_registered_modules(void* t_func)
 
 GobindModule* call_gobind_module_init(void* t_func)
 {
-  return ((gobind_fn_ptr)t_func)();
+  return ((gobind_module_init_fn_ptr)t_func)();
+}
+
+void call_gobind_module_pprint(void* t_func, void* t_module)
+{
+  return ((gobind_module_pprint_fn_ptr)t_func)(t_module);
 }
 
 const char* call_gtype2str(void* t_func, const GType t_type)

--- a/src/lib/cgobind/cgobind_helper.h
+++ b/src/lib/cgobind/cgobind_helper.h
@@ -5,7 +5,7 @@
  * @file
  *
  * This file is intended to be used by the gobind command cgobind package.
- * In here is everything needed for 
+ * In here is everything needed for
  */
 
 // Library Includes:
@@ -18,6 +18,7 @@
 void* call_void_func(void* t_func);
 GobindRegistery* call_registered_modules(void* t_func);
 GobindModule* call_gobind_module_init(void* t_func);
+void call_gobind_module_pprint(void* t_func, void* t_module);
 const char* call_gtype2str(void* t_func, const GType t_type);
 
 #endif // CGOBIND_HELPER_H

--- a/src/lib/cgobind/gtype2golang.c
+++ b/src/lib/cgobind/gtype2golang.c
@@ -16,8 +16,8 @@ const char* gtype2golang(GType t_gtype)
     GTYPE2STR(GTYPE_CHAR, "byte");
 
     // Floating point:
-    GTYPE2STR(GTYPE_FLOAT, "float");
-    GTYPE2STR(GTYPE_DOUBLE, "double");
+    GTYPE2STR(GTYPE_FLOAT, "float32");
+    GTYPE2STR(GTYPE_DOUBLE, "float64");
 
     // Integers:
     GTYPE2STR(GTYPE_SHORT, "int");
@@ -47,6 +47,53 @@ const char* gtype2golang(GType t_gtype)
       str = "UNKNOWN";
       break;
   }
+
+  return str;
+}
+
+const char* gtype2cgotype(GType t_gtype)
+{
+  const char* str = NULL;
+
+ 	// Void is no return type but when we return void*.
+	// This should return a `unsafe.Pointer`.
+  switch(t_gtype) {
+    GTYPE2STR(GTYPE_VOID, "");
+    GTYPE2STR(GTYPE_CHAR, "C.char");
+
+    // Floating point:
+    GTYPE2STR(GTYPE_FLOAT, "C.float");
+    GTYPE2STR(GTYPE_DOUBLE, "C.double");
+
+    // Integers:
+    GTYPE2STR(GTYPE_SHORT, "C.short");
+    GTYPE2STR(GTYPE_INT, "C.int");
+    GTYPE2STR(GTYPE_LONG, "C.long");
+    GTYPE2STR(GTYPE_LONG_LONG, "C.longlong");
+
+    // Unsigned integers:
+    GTYPE2STR(GTYPE_USHORT, "C.ushort");
+    GTYPE2STR(GTYPE_UINT, "C.uint");
+    GTYPE2STR(GTYPE_ULONG, "C.ulong");
+    GTYPE2STR(GTYPE_ULONG_LONG, "C.ulonglong");
+
+		// TODO: This must be implemented.
+    // Fixed width integers:
+    GTYPE2STR(GTYPE_INT8, "int");
+    GTYPE2STR(GTYPE_INT16, "int");
+    GTYPE2STR(GTYPE_INT32, "int");
+    GTYPE2STR(GTYPE_INT64, "int");
+
+    // Fixed width unsigned integers:
+    GTYPE2STR(GTYPE_UINT8, "int");
+    GTYPE2STR(GTYPE_UINT16, "int");
+    GTYPE2STR(GTYPE_UINT32, "int");
+    GTYPE2STR(GTYPE_UINT64, "int");
+
+    default:
+      str = "UNKNOWN";
+      break;
+  }	/*  */
 
   return str;
 }

--- a/src/lib/cgobind/gtype2golang.h
+++ b/src/lib/cgobind/gtype2golang.h
@@ -9,6 +9,10 @@
 #include <gobind/gobind.h>
 
 // Functions:
+//! Convert a @ref GType to a Golang native type.
 const char* gtype2golang(GType t_gtype);
+
+//! Convert a @ref GType to a Golang cgo type.
+const char* gtype2cgotype(GType t_gtype);
 
 #endif // GTYP2GO_H

--- a/src/lib/cgobind/gtype2golang.h
+++ b/src/lib/cgobind/gtype2golang.h
@@ -1,5 +1,5 @@
-#ifndef GTYP2GO_H
-#define GTYP2GO_H
+#ifndef GTYPE2GOLANG_H
+#define GTYPE2GOLANG_H
 
 /*!
  * @file
@@ -15,4 +15,4 @@ const char* gtype2golang(GType t_gtype);
 //! Convert a @ref GType to a Golang cgo type.
 const char* gtype2cgotype(GType t_gtype);
 
-#endif // GTYP2GO_H
+#endif // GTYPE2GOLANG_H

--- a/src/lib/gobind/gobind_function_table.cpp
+++ b/src/lib/gobind/gobind_function_table.cpp
@@ -90,27 +90,6 @@ Error gobind_function_table_add(GobindFunctionTable* t_fn_table,
   return error;
 }
 
-void gobind_function_pprint(const GobindFunction* t_fn)
-{
-  if(!t_fn) {
-    std::cerr << "GobindFunction nil!";
-    return;
-  }
-}
-
-void gobind_function_table_pprint(const GobindFunctionTable* t_fn_table)
-{
-  if(!t_fn_table) {
-    std::cerr << "GobindFunctionTable nil!";
-    return;
-  }
-
-  for(size_t index{0}; index < t_fn_table->m_size; index++) {
-    const auto& fn{t_fn_table->m_functions[index]};
-    gobind_function_pprint(&fn);
-  }
-}
-
 void gobind_function_table_free(GobindFunctionTable** t_fn_table)
 {
   // FIXME: Check if t_fn_table is nullptr (nullptr dereference).
@@ -134,3 +113,30 @@ void gobind_function_table_free(GobindFunctionTable** t_fn_table)
 
   fn_table_ptr = nullptr;
 }
+
+// Utility:
+void gobind_function_pprint(const GobindFunction* t_fn)
+{
+  if(!t_fn) {
+    std::cerr << "GobindFunction nil!";
+    return;
+  }
+}
+
+void gobind_function_table_pprint(const GobindFunctionTable* t_fn_table)
+{
+  if(!t_fn_table) {
+    std::cerr << "GobindFunctionTable nil!";
+    return;
+  }
+
+  const auto fn_size{t_fn_table->m_size};
+  for(size_t index{0}; index < fn_size; index++) {
+    std::cout << "# Entry " << index << '/' << fn_size << ".\n";
+    const auto& fn{t_fn_table->m_functions[index]};
+    gobind_function_pprint(&fn);
+
+    std::cout << '\n';
+  }
+}
+

--- a/src/lib/gobind/gobind_function_table.cpp
+++ b/src/lib/gobind/gobind_function_table.cpp
@@ -6,41 +6,19 @@
 // Local Includes:
 #include "alloc.hpp"
 
-/*
-// Internal:
-namespace {
-template<typename T>
-auto reallocate(T** array, size_t& capacity) -> void
-{
-  if(new_capacity <= capacity)
-    return; // No need to shrink
-
-  T* new_array = new T[new_capacity];
-
-  // Copy existing elements to the new array
-  std::memcpy(new_array, array, capacity * sizeof(T));
-
-  // Delete the old array
-  delete[] array;
-
-  // Update pointer and capacity
-  array = new_array;
-  capacity = new_capacity;
-}
-} // namespace
-*/
-
-
 // Functions:
 Error gobind_function_table_create(GobindFunctionTable** t_fn_table)
 {
   using gobind::malloc;
 
+  // Arbitrary default starting capacity.
+  constexpr auto default_capacity{8};
+
   auto& ptr{*t_fn_table};
-  ptr = malloc<GobindFunctionTable>();
+  ptr = malloc<GobindFunctionTable>(default_capacity);
   ptr->m_functions = malloc<GobindFunction>();
   ptr->m_size = 0;
-  ptr->m_capacity = 0;
+  ptr->m_capacity = default_capacity;
 
   return {};
 }
@@ -137,7 +115,7 @@ void gobind_function_table_pprint(const GobindFunctionTable* t_fn_table)
 
   const auto fn_size{t_fn_table->m_size};
 
-  std::cout << t_fn_table->m_capacity << '\n';
+  std::cout << "Cap: " << t_fn_table->m_capacity << '\n';
 
   for(size_t index{0}; index < fn_size; index++) {
     std::cout << "# Entry " << index << '/' << fn_size << ".\n";

--- a/src/lib/gobind/gobind_function_table.cpp
+++ b/src/lib/gobind/gobind_function_table.cpp
@@ -136,6 +136,9 @@ void gobind_function_table_pprint(const GobindFunctionTable* t_fn_table)
   }
 
   const auto fn_size{t_fn_table->m_size};
+
+  std::cout << t_fn_table->m_capacity << '\n';
+
   for(size_t index{0}; index < fn_size; index++) {
     std::cout << "# Entry " << index << '/' << fn_size << ".\n";
     const auto& fn{t_fn_table->m_functions[index]};

--- a/src/lib/gobind/gobind_function_table.cpp
+++ b/src/lib/gobind/gobind_function_table.cpp
@@ -90,6 +90,27 @@ Error gobind_function_table_add(GobindFunctionTable* t_fn_table,
   return error;
 }
 
+void gobind_function_pprint(const GobindFunction* t_fn)
+{
+  if(!t_fn) {
+    std::cerr << "GobindFunction nil!";
+    return;
+  }
+}
+
+void gobind_function_table_pprint(const GobindFunctionTable* t_fn_table)
+{
+  if(!t_fn_table) {
+    std::cerr << "GobindFunctionTable nil!";
+    return;
+  }
+
+  for(size_t index{0}; index < t_fn_table->m_size; index++) {
+    const auto& fn{t_fn_table->m_functions[index]};
+    gobind_function_pprint(&fn);
+  }
+}
+
 void gobind_function_table_free(GobindFunctionTable** t_fn_table)
 {
   // FIXME: Check if t_fn_table is nullptr (nullptr dereference).

--- a/src/lib/gobind/gobind_function_table.cpp
+++ b/src/lib/gobind/gobind_function_table.cpp
@@ -121,6 +121,11 @@ void gobind_function_pprint(const GobindFunction* t_fn)
     std::cerr << "GobindFunction nil!";
     return;
   }
+
+  // clang-format off
+	std::cout << "\t" << t_fn->m_name << '\n';
+
+  // clang-format on
 }
 
 void gobind_function_table_pprint(const GobindFunctionTable* t_fn_table)
@@ -139,4 +144,3 @@ void gobind_function_table_pprint(const GobindFunctionTable* t_fn_table)
     std::cout << '\n';
   }
 }
-

--- a/src/lib/gobind/gobind_function_table.h
+++ b/src/lib/gobind/gobind_function_table.h
@@ -53,6 +53,10 @@ Error gobind_function_table_resize(GobindFunctionTable* t_fn_table,
                                    size_t t_size);
 Error gobind_function_table_add(GobindFunctionTable* t_fn_table,
                                 GobindFunction* t_function);
+
+void gobind_function_pprint(const GobindFunction* t_fn);
+void gobind_function_table_pprint(const GobindFunctionTable* t_fn_table);
+
 void gobind_function_table_free(GobindFunctionTable** t_fn_table);
 
 #ifdef __cplusplus

--- a/src/lib/gobind/gobind_function_table.h
+++ b/src/lib/gobind/gobind_function_table.h
@@ -54,10 +54,11 @@ Error gobind_function_table_resize(GobindFunctionTable* t_fn_table,
 Error gobind_function_table_add(GobindFunctionTable* t_fn_table,
                                 GobindFunction* t_function);
 
+void gobind_function_table_free(GobindFunctionTable** t_fn_table);
+
+// Utility:
 void gobind_function_pprint(const GobindFunction* t_fn);
 void gobind_function_table_pprint(const GobindFunctionTable* t_fn_table);
-
-void gobind_function_table_free(GobindFunctionTable** t_fn_table);
 
 #ifdef __cplusplus
 }

--- a/src/lib/gobind/gobind_module.cpp
+++ b/src/lib/gobind/gobind_module.cpp
@@ -41,20 +41,6 @@ Error gobind_module_create(GobindModule** t_module, const char* t_name)
   return error;
 }
 
-// TODO: One day clean this code up, maybe use an actual logging library.
-void gobind_module_pprint(const GobindModule* t_module)
-{
-  if(!t_module) {
-    std::cerr << "GobindModule nil!";
-    return;
-  }
-
-  const auto& [name, fn_table] = *t_module;
-
-  std::cout << "# GobindModule: " << name << '\n';
-  gobind_function_table_pprint((const GobindFunctionTable*)&fn_table);
-}
-
 void gobind_module_free(GobindModule** t_module)
 {
   // FIXME: Check if t_module is nullptr (nullptr dereference).
@@ -65,4 +51,19 @@ void gobind_module_free(GobindModule** t_module)
   std::free(module_ptr);
 
   module_ptr = nullptr;
+}
+
+// Utility:
+// TODO: One day clean this code up, maybe use an actual logging library.
+void gobind_module_pprint(const GobindModule* t_module)
+{
+  if(!t_module) {
+    std::cerr << "GobindModule nil!";
+    return;
+  }
+
+  const auto& [name, fn_table] = *t_module;
+
+  std::cout << "# GobindModule: " << std::quoted(name) << ".\n";
+  gobind_function_table_pprint((const GobindFunctionTable*)&fn_table);
 }

--- a/src/lib/gobind/gobind_module.cpp
+++ b/src/lib/gobind/gobind_module.cpp
@@ -7,6 +7,9 @@
 #include <iostream>
 #include <string_view>
 
+// C Includes:
+#include "gobind_function_table.h"
+
 // Local Includes:
 #include "alloc.hpp"
 #include "gobind_module_factory.hpp"
@@ -39,7 +42,7 @@ Error gobind_module_create(GobindModule** t_module, const char* t_name)
 }
 
 // TODO: One day clean this code up, maybe use an actual logging library.
-void gobind_module_pprint(GobindModule* t_module)
+void gobind_module_pprint(const GobindModule* t_module)
 {
   if(!t_module) {
     std::cerr << "GobindModule nil!";
@@ -49,6 +52,7 @@ void gobind_module_pprint(GobindModule* t_module)
   const auto& [name, fn_table] = *t_module;
 
   std::cout << "# GobindModule: " << name << '\n';
+  gobind_function_table_pprint((const GobindFunctionTable*)&fn_table);
 }
 
 void gobind_module_free(GobindModule** t_module)

--- a/src/lib/gobind/gobind_module.cpp
+++ b/src/lib/gobind/gobind_module.cpp
@@ -38,6 +38,19 @@ Error gobind_module_create(GobindModule** t_module, const char* t_name)
   return error;
 }
 
+// TODO: One day clean this code up, maybe use an actual logging library.
+void gobind_module_pprint(GobindModule* t_module)
+{
+  if(!t_module) {
+    std::cerr << "GobindModule nil!";
+    return;
+  }
+
+  const auto& [name, fn_table] = *t_module;
+
+  std::cout << "# GobindModule: " << name << '\n';
+}
+
 void gobind_module_free(GobindModule** t_module)
 {
   // FIXME: Check if t_module is nullptr (nullptr dereference).

--- a/src/lib/gobind/gobind_module.h
+++ b/src/lib/gobind/gobind_module.h
@@ -32,14 +32,15 @@ typedef struct {
 Error gobind_module_create(GobindModule** t_module, const char* t_name);
 void gobind_module_invalid_name(const char* t_name);
 
-// One day clean the pretty print code up, maybe use an actual logging utility.
+void gobind_module_free(GobindModule** t_module);
+
+// Utility:
+// FIXME: One day clean the pretty print code up, maybe use actual logging.
 /*!
  * Pretty print everything in the @ref GobindModule.
  * @note useful for debugging generated libraries, from golang.
  */
 void gobind_module_pprint(const GobindModule* t_module);
-
-void gobind_module_free(GobindModule** t_module);
 
 #ifdef __cplusplus
 }

--- a/src/lib/gobind/gobind_module.h
+++ b/src/lib/gobind/gobind_module.h
@@ -31,10 +31,15 @@ typedef struct {
 // Functions:
 Error gobind_module_create(GobindModule** t_module, const char* t_name);
 void gobind_module_invalid_name(const char* t_name);
-// Error gobind_module_add_function(GobindModule* t_module, );
-// Error gobind_module_add_struct(GobindModule* t_module, );
-void gobind_module_free(GobindModule** t_module);
 
+// One day clean the pretty print code up, maybe use an actual logging utility.
+/*!
+ * Pretty print everything in the @ref GobindModule.
+ * @note useful for debugging generated libraries, from golang.
+ */
+void gobind_module_pprint(GobindModule* t_module);
+
+void gobind_module_free(GobindModule** t_module);
 
 #ifdef __cplusplus
 }

--- a/src/lib/gobind/gobind_module.h
+++ b/src/lib/gobind/gobind_module.h
@@ -1,5 +1,5 @@
-#ifndef GOLANG_MODULE_HPP
-#define GOLANG_MODULE_HPP
+#ifndef GOBIND_MODULE_HPP
+#define GOBIND_MODULE_HPP
 
 /*!
  * @file
@@ -37,7 +37,7 @@ void gobind_module_invalid_name(const char* t_name);
  * Pretty print everything in the @ref GobindModule.
  * @note useful for debugging generated libraries, from golang.
  */
-void gobind_module_pprint(GobindModule* t_module);
+void gobind_module_pprint(const GobindModule* t_module);
 
 void gobind_module_free(GobindModule** t_module);
 
@@ -45,4 +45,4 @@ void gobind_module_free(GobindModule** t_module);
 }
 #endif /* __cplusplus */
 
-#endif // GOLANG_MODULE_HPP
+#endif // GOBIND_MODULE_HPP

--- a/src/lib/gobind/gobind_module_factory.cpp
+++ b/src/lib/gobind/gobind_module_factory.cpp
@@ -23,7 +23,7 @@ auto GobindModuleFactory::compile_module() -> void
   const auto size{m_fn_list.size()};
   auto& fn_table{m_module->m_fn_table};
 
-  // Resize too the size we need as we already know the size.
+  // Resize to the size we need as we already have computed the size.
   gobind_function_table_resize(fn_table, size);
 
   // TODO: We could be more efficient by doing a raw copy.

--- a/src/lib/gobind/gobind_module_factory.hpp
+++ b/src/lib/gobind/gobind_module_factory.hpp
@@ -74,13 +74,15 @@ auto GobindModuleFactory::def(const char* t_name, Ret (*t_fn)(Args...)) -> Error
 
   auto index{0};
   for(auto&& sym : params) {
-    //FIXME: lazy logging.
+    // FIXME: lazy logging.
     // clang-format off
+		/*
     std::cout << "Name: " << t_name
 	      << " Param: " << ((sym.m_constant) ? "const " : "" )
 	      << gtype2str(sym.m_type)
 	      << ' ' << ((sym.m_pointer > 0) ? "*" : "")
 	      << '\n';
+				*/
     // clang-format on
 
     fn.m_params[index] = sym;


### PR DESCRIPTION
Adding support for converting parameters and passing these to C++ functions.
I should also add a more lean API for using the library from pure C (this might be horrendous and require implementation from the gobind side, with access to the headers and parsing those).

So the idea is to convert `GType` to a Golang type and cgo type for interacing with C native types.
Later we can support Structs that contain native types.
We can bypass any ABI compatibility issues, by retaining pointers to each member of a struct upon registration.
And then construct the struct using the same order of members specified.
(for this some kind of caster function would need to be made).
(this is not ideal, so another way must be found).

The development should be in baby steps, and soon we will need to do TDD for the entire pipeline to detect any anomalies since we are deep in ABI messing around territory.
For example I was curious how default parameters work in C++ and apparently the compiler just inserts the default argument at the call site of the function.

So if this is not encoded you get undefined behavior/unitialized data.
So safe to say we need to find a way to register default arguments.

The `GobindModule` struct is really starting to look like an AST slowly but surely.
